### PR TITLE
fix(json-schema): take into account environment

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/schema/json_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/schema/json_schema.py
@@ -271,6 +271,7 @@ class JsonSchemaSource(StatefulIngestionSourceBase):
                 platform=self.config.platform,
                 name=dataset_name,
                 platform_instance=self.config.platform_instance,
+                env=self.config.env,
             )
             yield MetadataChangeProposalWrapper(
                 entityUrn=dataset_urn, aspect=meta


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Documentation says I can set environment for JSON Schema https://datahubproject.io/docs/generated/ingestion/sources/json-schema, but it's not taken into account 
